### PR TITLE
@Gerglamesh, add includes for GetMammalByFamily-methods

### DIFF
--- a/MammalAPI/Configuration/Mapper.cs
+++ b/MammalAPI/Configuration/Mapper.cs
@@ -12,8 +12,15 @@ namespace MammalAPI.Configuration
     {
         public Mapper()
         {
-            CreateMap<Mammal, MammalDTO>().ReverseMap();
-            CreateMap<Habitat, HabitatDTO>().ReverseMap();
+            CreateMap<Mammal, MammalDTO>().ForMember(
+                dto => dto.Habitats,
+                opt => opt.MapFrom(x => x.MammalHabitats
+                    .Select(y => y.Habitat)
+                    .ToList()))
+                .ReverseMap();
+
+            CreateMap<Habitat, HabitatDTO>().ForMember(dto => dto.Mammal, opt => opt.MapFrom(x => x.MammalHabitats.Select(y => y.Mammal).ToList())).ReverseMap();
+
             CreateMap<Family, FamilyDTO>().ReverseMap();
         }
     }

--- a/MammalAPI/Controllers/MammalController.cs
+++ b/MammalAPI/Controllers/MammalController.cs
@@ -102,12 +102,34 @@ namespace MammalAPI.Controllers
         }
 
         [HttpGet("byfamilyname/{familyName}")]
-        public async Task<IActionResult> GetMammalsByFamilyName(string familyName)
+        public async Task<IActionResult> GetMammalsByFamilyName(string familyName, bool includeHabitat = false, bool includeFamily = false)
         {
             try
             {
-                var result= await _repository.GetMammalsByFamily(familyName);
+                var result = await _repository.GetMammalsByFamily(familyName, includeHabitat, includeFamily);
                 var mappedResult = _mapper.Map<List<MammalDTO>>(result);
+
+                //We have tried filtering in the repositroy but cannot find a good way to limit the recursion depth, hence why we've opted for this approach
+                //where we filter the DTO to stop recursion
+                if (includeHabitat)
+                {
+                    foreach (MammalDTO mammal in mappedResult)
+                    {
+                        foreach (HabitatDTO habitat in mammal.Habitats)
+                        {
+                            habitat.Mammal = null;
+                        }
+                    }                    
+                }
+
+                if (includeFamily)
+                {
+                    foreach (MammalDTO mammal in mappedResult)
+                    {
+                        mammal.Family.Mammals = null;
+                    }
+                }
+
                 return Ok(mappedResult);
             }
             catch (Exception e)
@@ -117,12 +139,34 @@ namespace MammalAPI.Controllers
         }
 
         [HttpGet("byfamilyid/{id}")]
-        public async Task<IActionResult> GetMammalsByFamilyId(int id)
+        public async Task<IActionResult> GetMammalsByFamilyId(int id, bool includeHabitat = false, bool includeFamily = false)
         {
             try
             {
-                var result= await _repository.GetMammalsByFamilyId(id);
+                var result= await _repository.GetMammalsByFamilyId(id, includeHabitat, includeFamily);
                 var mappedResult = _mapper.Map<List<MammalDTO>>(result);
+
+                //We have tried filtering in the repositroy but cannot find a good way to limit the recursion depth, hence why we've opted for this approach
+                //where we filter the DTO to stop recursion
+                if (includeHabitat)
+                {
+                    foreach (MammalDTO mammal in mappedResult)
+                    {
+                        foreach (HabitatDTO habitat in mammal.Habitats)
+                        {
+                            habitat.Mammal = null;
+                        }
+                    }
+                }
+
+                if (includeFamily)
+                {
+                    foreach (MammalDTO mammal in mappedResult)
+                    {
+                        mammal.Family.Mammals = null;
+                    }
+                }
+
                 return Ok(mappedResult);
             }
             catch (Exception e)

--- a/MammalAPI/Controllers/MammalsController.cs
+++ b/MammalAPI/Controllers/MammalsController.cs
@@ -14,12 +14,12 @@ namespace MammalAPI.Controllers
 {
     [ApiController]
     [Route("api/v1.0/[controller]")]
-    public class MammalController : HateoasMammalControllerBase
+    public class MammalsController : HateoasMammalControllerBase
     {
         private readonly IMammalRepository _repository;
         private readonly IMapper _mapper;
 
-        public MammalController(IMammalRepository repository, IMapper mapper, IActionDescriptorCollectionProvider actionDescriptorCollectionProvider) : base(actionDescriptorCollectionProvider)
+        public MammalsController(IMammalRepository repository, IMapper mapper, IActionDescriptorCollectionProvider actionDescriptorCollectionProvider) : base(actionDescriptorCollectionProvider)
         {
             _repository = repository;
             _mapper = mapper;

--- a/MammalAPI/Services/IMammalRepository.cs
+++ b/MammalAPI/Services/IMammalRepository.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using AutoMapper;
 using MammalAPI.DTO;
 using MammalAPI.Models;
 
@@ -12,7 +13,7 @@ namespace MammalAPI.Services
         Task<List<Mammal>> GetMammalsByHabitatId(int id);
         Task<List<Mammal>> GetMammalsByHabitat(string habitatName);
         Task<List<Mammal>> GetMammalsByLifeSpan(int fromYear, int toYear);
-        Task<List<Mammal>> GetMammalsByFamily(string familyName);
-        Task<List<Mammal>> GetMammalsByFamilyId(int id);
+        Task<List<Mammal>> GetMammalsByFamily(string familyName, bool includeHabitat, bool includeFamily = false);
+        Task<List<Mammal>> GetMammalsByFamilyId(int id, bool includeHabitat = false, bool includeFamily = false);
     }
 }

--- a/MammalAPI/Services/MammalRepository.cs
+++ b/MammalAPI/Services/MammalRepository.cs
@@ -80,23 +80,42 @@ namespace MammalAPI.Services
             return await query.ToListAsync(); 
         }
 
-        public async Task<List<Mammal>> GetMammalsByFamily(string familyName)
+        public async Task<List<Mammal>> GetMammalsByFamily(string familyName, bool includeHabitat = false, bool includeFamily = false)
         {
             _logger.LogInformation($"Getting mammals by familyname {familyName}");
 
             var query = _dBContext.Mammals
                 .Where(f => f.Family.Name == familyName);
 
+            if (includeHabitat)
+            {
+                query = query.Include(m => m.MammalHabitats).ThenInclude(mh => mh.Habitat);
+            }
+
+            if (includeFamily)
+            {
+                query = query.Include(m => m.Family);
+            }
+
             return await query.ToListAsync();
         }
 
-        public async Task<List<Mammal>> GetMammalsByFamilyId(int id)
+        public async Task<List<Mammal>> GetMammalsByFamilyId(int id, bool includeHabitat = false, bool includeFamily = false)
         {
             _logger.LogInformation($"Getting mammals by familyid {id}");
 
             var query = _dBContext.Mammals
                 .Where(m => m.Family.FamilyId == id);
-                
+
+            if (includeHabitat)
+            {
+                query = query.Include(m => m.MammalHabitats).ThenInclude(mh => mh.Habitat);
+            }
+
+            if (includeFamily)
+            {
+                query = query.Include(m => m.Family);
+            }
 
             return await query.ToListAsync();
         }

--- a/MammalAPI/Startup.cs
+++ b/MammalAPI/Startup.cs
@@ -30,7 +30,6 @@ namespace MammalAPI
             services.AddControllers().AddNewtonsoftJson(options =>
             {
                 options.SerializerSettings.ReferenceLoopHandling = Newtonsoft.Json.ReferenceLoopHandling.Ignore;
-
             });
 
             services.AddSwaggerGen(c =>


### PR DESCRIPTION
There was a lot of trouble getting this to work, when we finally bridged the jointable to be able to include the relationships with habitat we encountered a problem with recursion depth where the API would display the same information many times. 

To get around this problem I got some input from a friend. Until this point I had tried filtering the data fetched from the db in the repo, with marginal success (got problems with includes when I wanted to be able to choose to include two different pieces of info). My friend suggested filtering the DTO in the controller instead, which worked wonderfully.

The drawback with this solution is that unnecessary data is fecthed from the database and then filtered out in the controller, I would've liked a solution where the data is filtered earlier in the process but can't find any good alternatives. So this solution is good enough in my opinion.